### PR TITLE
Refactor jet collection merging with configurable b-tag threshold

### DIFF
--- a/configs/HH4b_common/config_files/default_config.py
+++ b/configs/HH4b_common/config_files/default_config.py
@@ -57,13 +57,9 @@ default_config_options_dict = {
     "only5jetsbSF": False,
     "noL1": False,
     "approach": "first",
-    # Apply the pT regression *with* neutrinos only to jets with a high b-tag
-    # score and the regression *without* neutrinos to the remaining jets.
-    #   None  -> feature disabled (default first/second approach behaviour)
-    #   True  -> enabled, threshold = loose ("L") WP of the tagger used
-    #   "M"/"T"/... -> enabled, threshold = that WP of the tagger used
-    #   float -> enabled, threshold = that raw b-tag discriminant value
-    # The tagger and its working points are read from the b-tagging parameters.
+    # +neutrino regression for high-b-tag jets, plain regression for the rest.
+    # None -> disabled; True -> loose WP; a WP name ("M"/"T"/...) or a raw b-tag
+    # score -> that threshold. Tagger/WPs read from the b-tagging parameters.
     "neutrino_regression_btag_cut": None,
     "expandCR": False,
     "mixeddata": False

--- a/configs/HH4b_common/config_files/default_config.py
+++ b/configs/HH4b_common/config_files/default_config.py
@@ -57,6 +57,14 @@ default_config_options_dict = {
     "only5jetsbSF": False,
     "noL1": False,
     "approach": "first",
+    # Apply the pT regression *with* neutrinos only to jets with a high b-tag
+    # score and the regression *without* neutrinos to the remaining jets.
+    #   None  -> feature disabled (default first/second approach behaviour)
+    #   True  -> enabled, threshold = loose ("L") WP of the tagger used
+    #   "M"/"T"/... -> enabled, threshold = that WP of the tagger used
+    #   float -> enabled, threshold = that raw b-tag discriminant value
+    # The tagger and its working points are read from the b-tagging parameters.
+    "neutrino_regression_btag_cut": None,
     "expandCR": False,
     "mixeddata": False
 } | default_onnx_model_dict

--- a/configs/HH4b_common/config_files/pt_vary_btagWP_VBF_SeparateHiggsVBF_AddVBFJetPtOrder_NeutrinoAboveLoose.py
+++ b/configs/HH4b_common/config_files/pt_vary_btagWP_VBF_SeparateHiggsVBF_AddVBFJetPtOrder_NeutrinoAboveLoose.py
@@ -1,0 +1,32 @@
+import configs.HH4b_common.dnn_input_variables as dnn_vars
+
+
+from configs.HH4b_common.config_files.default_config import default_onnx_model_dict as onnx_model_dict
+
+from configs.HH4b_common.config_files.default_config import default_config_options_dict as config_options_dict
+
+
+
+config_options_dict |= {
+    "dnn_variables": False,
+    "run2": False,
+    "sig_bkg_dnn_input_variables": None,
+    "bkg_morphing_dnn_input_variables": None,
+    "max_num_jets_good": 4,
+    "which_bquark": "last",
+    "fifth_jet": "pt",
+    "pad_value": -999.0,
+    "add_jet_spanet": True,
+    "qt_postEE": None,
+    "random_pt": True,
+    "rand_type": 0.3,
+    # "save_chunk":"root://t3dcachedb03.psi.ch:1094//pnfs/psi.ch/cms/trivcat/store/user/mmalucch/out_hh4b/VBF/out_ggf_vbf_spanet_input_SM_ptFlattenMatchedHiggs_AllKlambda_DetaMjj_SeparateHiggsVBF_AddVBFJetPtOrder_Fix/parquet_files/",
+    "neutrino_regression_btag_cut": True,
+    # VBF
+    "vbf_parton_matching": True,
+    "vbf_presel": False,
+    "vbf_analysis": True,
+    "which_vbf_quark":"with_mothers_children",
+    "max_num_jets_add_vbf": 3,
+    "jets_add_vbf_order": "pt",
+}| onnx_model_dict

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -5,6 +5,7 @@ import awkward as ak
 import numpy as np
 import vector
 from pocket_coffea.lib.deltaR_matching import object_matching
+from pocket_coffea.lib.jets import merge_regressed_jets_by_btag
 from pocket_coffea.workflows.base import BaseProcessorABC
 
 from utils_configs.basic_functions import add_fields, compute_fw_momenta
@@ -141,79 +142,6 @@ class HH4bCommonProcessor(BaseProcessorABC):
         self.events["JetPNet"] = copy.copy(self.events["Jet"])
         self.events["JetPNetPlusNeutrino"] = copy.copy(self.events["Jet"])
 
-    def get_neutrino_regression_btag_cut(self):
-        """Resolve the b-tag discriminant and threshold used to decide whether a
-        jet gets the pT regression *with* neutrinos.
-
-        The tagger is read from the b-tagging parameters
-        (``btagging.working_point.<year>.btagging_algorithm``) so that the
-        correct discriminant is used for each year/tagger definition. The
-        threshold is controlled by the ``neutrino_regression_btag_cut`` workflow
-        option:
-
-        * ``True``       -> loose (``"L"``) working point of the tagger (default)
-        * a WP string    -> that working point (e.g. ``"M"``, ``"T"``) of the tagger
-        * a ``float``    -> used directly as the raw b-tag discriminant threshold
-
-        Returns:
-            (tagger_branch, threshold): name of the jet b-tag field and the
-            numeric threshold to apply on it.
-        """
-        wp_params = self.params["btagging"]["working_point"][self._year]
-        tagger = wp_params["btagging_algorithm"]
-        cut = self.neutrino_regression_btag_cut
-        if cut is True:
-            # default: loose working point of the tagger used
-            threshold = wp_params["btagging_WP"][tagger]["L"]
-        elif isinstance(cut, str):
-            # a working point name (e.g. "L", "M", "T")
-            threshold = wp_params["btagging_WP"][tagger][cut]
-        else:
-            # a raw discriminant value
-            threshold = cut
-        return tagger, threshold
-
-    def merge_regression_by_btag(self):
-        """Build the ``Jet`` collection splitting the regression by b-tag score.
-
-        Jets with a b-tag discriminant above the threshold get the regression
-        *with* neutrinos (``JetPNetPlusNeutrino``); the remaining jets get the
-        regression *without* neutrinos (``JetPNet``). Jets for which the
-        requested regression is not valid fall back to the standard, JEC-only
-        collection (``JetDefault``).
-        """
-        for coll in ("JetDefault", "JetPNet", "JetPNetPlusNeutrino"):
-            if coll not in self.events.fields:
-                raise ValueError(
-                    f"Collection '{coll}' is required by neutrino_regression_btag_cut "
-                    "but was not found. Make sure define_jet_collections() is called "
-                    "and the corresponding jet calibration (AK4PFPuppiPNetRegression and "
-                    "AK4PFPuppiPNetRegressionPlusNeutrino) is configured."
-                )
-
-        tagger, threshold = self.get_neutrino_regression_btag_cut()
-
-        # b-tag score is not modified by the regression (only pt/mass/rawFactor
-        # change), so it can be read from any of the regressed collections.
-        high_btag = self.events["JetPNet"][tagger] >= threshold
-        neutrino_valid = (
-            ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0
-        )
-        plain_valid = ak.nan_to_num(self.events["JetPNet"].pt, nan=-1) > 0
-
-        # jets below the b-tag cut (or without a valid +neutrino regression) get
-        # the regression without neutrinos where available, otherwise the default
-        jet_regressed = ak.where(
-            plain_valid,
-            self.events["JetPNet"],
-            self.events["JetDefault"],
-        )
-        return ak.where(
-            high_btag & neutrino_valid,
-            self.events["JetPNetPlusNeutrino"],
-            jet_regressed,
-        )
-
     def apply_object_preselection(self, variation):
         # Use the regressed pt from PNet+Neutrino collection if available,
         # otherwise use the JEC corrected pt collection
@@ -222,9 +150,25 @@ class HH4bCommonProcessor(BaseProcessorABC):
         if self.neutrino_regression_btag_cut is not None:
             # Apply the regression *with* neutrinos only to jets with a high
             # b-tag score and the regression *without* neutrinos to the rest.
-            # The tagger and the threshold (loose WP by default) are read from
-            # the b-tagging parameters (see get_neutrino_regression_btag_cut).
-            self.events["Jet"] = self.merge_regression_by_btag()
+            # The split is delegated to the PocketCoffea framework helper, which
+            # reads the tagger and the threshold (loose WP by default) from the
+            # b-tagging parameters.
+            for coll in ("JetDefault", "JetPNet", "JetPNetPlusNeutrino"):
+                if coll not in self.events.fields:
+                    raise ValueError(
+                        f"Collection '{coll}' is required by neutrino_regression_btag_cut "
+                        "but was not found. Make sure define_jet_collections() is called "
+                        "and the corresponding jet calibration (AK4PFPuppiPNetRegression and "
+                        "AK4PFPuppiPNetRegressionPlusNeutrino) is configured."
+                    )
+            self.events["Jet"] = merge_regressed_jets_by_btag(
+                jets_regressed=self.events["JetPNet"],
+                jets_regressed_neutrino=self.events["JetPNetPlusNeutrino"],
+                params=self.params,
+                year=self._year,
+                jets_fallback=self.events["JetDefault"],
+                btag_cut=self.neutrino_regression_btag_cut,
+            )
         elif self.approach == "first":
             self.events["Jet"] = ak.where(
                 ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0,

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -5,10 +5,7 @@ import awkward as ak
 import numpy as np
 import vector
 from pocket_coffea.lib.deltaR_matching import object_matching
-from pocket_coffea.lib.jets import (
-    merge_regressed_and_standard_jets,
-    merge_regressed_jets_by_btag,
-)
+from pocket_coffea.lib.jets import merge_regressed_jets
 from pocket_coffea.workflows.base import BaseProcessorABC
 
 from utils_configs.basic_functions import add_fields, compute_fw_momenta
@@ -153,9 +150,11 @@ class HH4bCommonProcessor(BaseProcessorABC):
         if self.neutrino_regression_btag_cut is not None:
             # Apply the regression *with* neutrinos only to jets with a high
             # b-tag score and the regression *without* neutrinos to the rest.
-            # The split is delegated to the PocketCoffea framework helper, which
+            # The merge is delegated to the PocketCoffea framework helper, which
             # reads the tagger and the threshold (loose WP by default) from the
-            # b-tagging parameters.
+            # b-tagging parameters. The neutrino_regression_btag_cut option
+            # selects the threshold: True -> loose WP, a WP name (e.g. "M") or a
+            # raw b-tag discriminant value.
             for coll in ("JetDefault", "JetPNet", "JetPNetPlusNeutrino"):
                 if coll not in self.events.fields:
                     raise ValueError(
@@ -164,31 +163,43 @@ class HH4bCommonProcessor(BaseProcessorABC):
                         "and the corresponding jet calibration (AK4PFPuppiPNetRegression and "
                         "AK4PFPuppiPNetRegressionPlusNeutrino) is configured."
                     )
-            self.events["Jet"] = merge_regressed_jets_by_btag(
-                jets_regressed=self.events["JetPNet"],
-                jets_regressed_neutrino=self.events["JetPNetPlusNeutrino"],
+            cut = self.neutrino_regression_btag_cut
+            btag_wp = cut if isinstance(cut, str) else ("L" if cut is True else None)
+            btag_score = None if isinstance(cut, (bool, str)) else cut
+            self.events["Jet"] = merge_regressed_jets(
+                # high b-tag jets: regression + neutrinos (falling back to the
+                # regression without neutrinos, then to the JEC-only jets)
+                jets_high_btag=[
+                    self.events["JetPNetPlusNeutrino"],
+                    self.events["JetPNet"],
+                    self.events["JetDefault"],
+                ],
+                # low b-tag jets: regression without neutrinos (falling back to
+                # the JEC-only jets)
+                jets_low_btag=[self.events["JetPNet"], self.events["JetDefault"]],
                 params=self.params,
                 year=self._year,
-                jets_fallback=self.events["JetDefault"],
-                btag_cut=self.neutrino_regression_btag_cut,
+                btag_wp=btag_wp,
+                btag_score=btag_score,
             )
         elif self.approach == "first":
             # Use the regressed (+neutrino) jets where the regression is valid,
             # otherwise fall back to the standard JEC jets.
-            self.events["Jet"] = merge_regressed_and_standard_jets(
-                jets_standard=self.events["JetDefault"],
-                jets_regressed=self.events["JetPNetPlusNeutrino"],
+            self.events["Jet"] = merge_regressed_jets(
+                [self.events["JetPNetPlusNeutrino"], self.events["JetDefault"]],
             )
         elif self.approach == "second":
             # As "first", but high-b-tag jets always use the regression, even
             # where the regression pt is not valid (loose WP of the tagger,
             # read from the b-tagging parameters).
-            self.events["Jet"] = merge_regressed_and_standard_jets(
-                jets_standard=self.events["JetDefault"],
-                jets_regressed=self.events["JetPNetPlusNeutrino"],
+            self.events["Jet"] = merge_regressed_jets(
+                jets_high_btag=self.events["JetPNetPlusNeutrino"],
+                jets_low_btag=[
+                    self.events["JetPNetPlusNeutrino"],
+                    self.events["JetDefault"],
+                ],
                 params=self.params,
                 year=self._year,
-                btag_cut=True,
             )
         else:
             raise ValueError(

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -5,7 +5,10 @@ import awkward as ak
 import numpy as np
 import vector
 from pocket_coffea.lib.deltaR_matching import object_matching
-from pocket_coffea.lib.jets import merge_regressed_jets_by_btag
+from pocket_coffea.lib.jets import (
+    merge_regressed_and_standard_jets,
+    merge_regressed_jets_by_btag,
+)
 from pocket_coffea.workflows.base import BaseProcessorABC
 
 from utils_configs.basic_functions import add_fields, compute_fw_momenta
@@ -170,22 +173,22 @@ class HH4bCommonProcessor(BaseProcessorABC):
                 btag_cut=self.neutrino_regression_btag_cut,
             )
         elif self.approach == "first":
-            self.events["Jet"] = ak.where(
-                ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0,
-                self.events["JetPNetPlusNeutrino"],
-                self.events.JetDefault,
+            # Use the regressed (+neutrino) jets where the regression is valid,
+            # otherwise fall back to the standard JEC jets.
+            self.events["Jet"] = merge_regressed_and_standard_jets(
+                jets_standard=self.events["JetDefault"],
+                jets_regressed=self.events["JetPNetPlusNeutrino"],
             )
         elif self.approach == "second":
-            self.events["Jet"] = ak.where(
-                (ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0)
-                | (
-                    self.events["JetPNetPlusNeutrino"].btagPNetB
-                    > self.params["btagging"]["working_point"][self._year][
-                        "btagging_WP"
-                    ]["btagPNetB"]["L"]
-                ),
-                self.events["JetPNetPlusNeutrino"],
-                self.events.JetDefault,
+            # As "first", but high-b-tag jets always use the regression, even
+            # where the regression pt is not valid (loose WP of the tagger,
+            # read from the b-tagging parameters).
+            self.events["Jet"] = merge_regressed_and_standard_jets(
+                jets_standard=self.events["JetDefault"],
+                jets_regressed=self.events["JetPNetPlusNeutrino"],
+                params=self.params,
+                year=self._year,
+                btag_cut=True,
             )
         else:
             raise ValueError(

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -145,7 +145,7 @@ class HH4bCommonProcessor(BaseProcessorABC):
     def apply_object_preselection(self, variation):
         # Build "Jet" from the regressed/standard collections. Taking a whole
         # collection (not just pt) keeps every pt-dependent field consistent.
-        if self.neutrino_regression_btag_cut is not None:
+        if self.approach == "first" and self.neutrino_regression_btag_cut is not None and self.neutrino_regression_btag_cut is not False:
             # +neutrino regression for high b-tag jets, plain regression for the
             # rest. The option sets the threshold: True -> loose WP, a WP name,
             # or a raw b-tag score.
@@ -158,6 +158,7 @@ class HH4bCommonProcessor(BaseProcessorABC):
                         "AK4PFPuppiPNetRegressionPlusNeutrino) is configured."
                     )
             cut = self.neutrino_regression_btag_cut
+            btag_algorithm = "btagPNetB"
             btag_wp = cut if isinstance(cut, str) else ("L" if cut is True else None)
             btag_score = None if isinstance(cut, (bool, str)) else cut
             self.events["Jet"] = merge_regressed_jets(
@@ -169,9 +170,11 @@ class HH4bCommonProcessor(BaseProcessorABC):
                 jets_low_btag=[self.events["JetPNet"], self.events["JetDefault"]],
                 params=self.params,
                 year=self._year,
+                btag_algorithm=btag_algorithm,
                 btag_wp=btag_wp,
                 btag_score=btag_score,
             )
+            breakpoint()
         elif self.approach == "first":
             # regressed (+neutrino) jets where valid, else the standard JEC jets
             self.events["Jet"] = merge_regressed_jets(

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -143,18 +143,12 @@ class HH4bCommonProcessor(BaseProcessorABC):
         self.events["JetPNetPlusNeutrino"] = copy.copy(self.events["Jet"])
 
     def apply_object_preselection(self, variation):
-        # Use the regressed pt from PNet+Neutrino collection if available,
-        # otherwise use the JEC corrected pt collection
-        # This way we consider correctly all fields which change depending on
-        # the pt definition, namely the pt, mass and the associated systematic variations
+        # Build "Jet" from the regressed/standard collections. Taking a whole
+        # collection (not just pt) keeps every pt-dependent field consistent.
         if self.neutrino_regression_btag_cut is not None:
-            # Apply the regression *with* neutrinos only to jets with a high
-            # b-tag score and the regression *without* neutrinos to the rest.
-            # The merge is delegated to the PocketCoffea framework helper, which
-            # reads the tagger and the threshold (loose WP by default) from the
-            # b-tagging parameters. The neutrino_regression_btag_cut option
-            # selects the threshold: True -> loose WP, a WP name (e.g. "M") or a
-            # raw b-tag discriminant value.
+            # +neutrino regression for high b-tag jets, plain regression for the
+            # rest. The option sets the threshold: True -> loose WP, a WP name,
+            # or a raw b-tag score.
             for coll in ("JetDefault", "JetPNet", "JetPNetPlusNeutrino"):
                 if coll not in self.events.fields:
                     raise ValueError(
@@ -167,15 +161,11 @@ class HH4bCommonProcessor(BaseProcessorABC):
             btag_wp = cut if isinstance(cut, str) else ("L" if cut is True else None)
             btag_score = None if isinstance(cut, (bool, str)) else cut
             self.events["Jet"] = merge_regressed_jets(
-                # high b-tag jets: regression + neutrinos (falling back to the
-                # regression without neutrinos, then to the JEC-only jets)
                 jets_high_btag=[
                     self.events["JetPNetPlusNeutrino"],
                     self.events["JetPNet"],
                     self.events["JetDefault"],
                 ],
-                # low b-tag jets: regression without neutrinos (falling back to
-                # the JEC-only jets)
                 jets_low_btag=[self.events["JetPNet"], self.events["JetDefault"]],
                 params=self.params,
                 year=self._year,
@@ -183,15 +173,12 @@ class HH4bCommonProcessor(BaseProcessorABC):
                 btag_score=btag_score,
             )
         elif self.approach == "first":
-            # Use the regressed (+neutrino) jets where the regression is valid,
-            # otherwise fall back to the standard JEC jets.
+            # regressed (+neutrino) jets where valid, else the standard JEC jets
             self.events["Jet"] = merge_regressed_jets(
                 [self.events["JetPNetPlusNeutrino"], self.events["JetDefault"]],
             )
         elif self.approach == "second":
-            # As "first", but high-b-tag jets always use the regression, even
-            # where the regression pt is not valid (loose WP of the tagger,
-            # read from the b-tagging parameters).
+            # as "first", but high b-tag jets (loose WP) always use the regression
             self.events["Jet"] = merge_regressed_jets(
                 jets_high_btag=self.events["JetPNetPlusNeutrino"],
                 jets_low_btag=[

--- a/configs/HH4b_common/workflow_common.py
+++ b/configs/HH4b_common/workflow_common.py
@@ -141,12 +141,91 @@ class HH4bCommonProcessor(BaseProcessorABC):
         self.events["JetPNet"] = copy.copy(self.events["Jet"])
         self.events["JetPNetPlusNeutrino"] = copy.copy(self.events["Jet"])
 
+    def get_neutrino_regression_btag_cut(self):
+        """Resolve the b-tag discriminant and threshold used to decide whether a
+        jet gets the pT regression *with* neutrinos.
+
+        The tagger is read from the b-tagging parameters
+        (``btagging.working_point.<year>.btagging_algorithm``) so that the
+        correct discriminant is used for each year/tagger definition. The
+        threshold is controlled by the ``neutrino_regression_btag_cut`` workflow
+        option:
+
+        * ``True``       -> loose (``"L"``) working point of the tagger (default)
+        * a WP string    -> that working point (e.g. ``"M"``, ``"T"``) of the tagger
+        * a ``float``    -> used directly as the raw b-tag discriminant threshold
+
+        Returns:
+            (tagger_branch, threshold): name of the jet b-tag field and the
+            numeric threshold to apply on it.
+        """
+        wp_params = self.params["btagging"]["working_point"][self._year]
+        tagger = wp_params["btagging_algorithm"]
+        cut = self.neutrino_regression_btag_cut
+        if cut is True:
+            # default: loose working point of the tagger used
+            threshold = wp_params["btagging_WP"][tagger]["L"]
+        elif isinstance(cut, str):
+            # a working point name (e.g. "L", "M", "T")
+            threshold = wp_params["btagging_WP"][tagger][cut]
+        else:
+            # a raw discriminant value
+            threshold = cut
+        return tagger, threshold
+
+    def merge_regression_by_btag(self):
+        """Build the ``Jet`` collection splitting the regression by b-tag score.
+
+        Jets with a b-tag discriminant above the threshold get the regression
+        *with* neutrinos (``JetPNetPlusNeutrino``); the remaining jets get the
+        regression *without* neutrinos (``JetPNet``). Jets for which the
+        requested regression is not valid fall back to the standard, JEC-only
+        collection (``JetDefault``).
+        """
+        for coll in ("JetDefault", "JetPNet", "JetPNetPlusNeutrino"):
+            if coll not in self.events.fields:
+                raise ValueError(
+                    f"Collection '{coll}' is required by neutrino_regression_btag_cut "
+                    "but was not found. Make sure define_jet_collections() is called "
+                    "and the corresponding jet calibration (AK4PFPuppiPNetRegression and "
+                    "AK4PFPuppiPNetRegressionPlusNeutrino) is configured."
+                )
+
+        tagger, threshold = self.get_neutrino_regression_btag_cut()
+
+        # b-tag score is not modified by the regression (only pt/mass/rawFactor
+        # change), so it can be read from any of the regressed collections.
+        high_btag = self.events["JetPNet"][tagger] >= threshold
+        neutrino_valid = (
+            ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0
+        )
+        plain_valid = ak.nan_to_num(self.events["JetPNet"].pt, nan=-1) > 0
+
+        # jets below the b-tag cut (or without a valid +neutrino regression) get
+        # the regression without neutrinos where available, otherwise the default
+        jet_regressed = ak.where(
+            plain_valid,
+            self.events["JetPNet"],
+            self.events["JetDefault"],
+        )
+        return ak.where(
+            high_btag & neutrino_valid,
+            self.events["JetPNetPlusNeutrino"],
+            jet_regressed,
+        )
+
     def apply_object_preselection(self, variation):
         # Use the regressed pt from PNet+Neutrino collection if available,
         # otherwise use the JEC corrected pt collection
         # This way we consider correctly all fields which change depending on
         # the pt definition, namely the pt, mass and the associated systematic variations
-        if self.approach == "first":
+        if self.neutrino_regression_btag_cut is not None:
+            # Apply the regression *with* neutrinos only to jets with a high
+            # b-tag score and the regression *without* neutrinos to the rest.
+            # The tagger and the threshold (loose WP by default) are read from
+            # the b-tagging parameters (see get_neutrino_regression_btag_cut).
+            self.events["Jet"] = self.merge_regression_by_btag()
+        elif self.approach == "first":
             self.events["Jet"] = ak.where(
                 ak.nan_to_num(self.events["JetPNetPlusNeutrino"].pt, nan=-1) > 0,
                 self.events["JetPNetPlusNeutrino"],


### PR DESCRIPTION
## Summary
This PR refactors the jet collection selection logic in the HH4b workflow to use a new `merge_regressed_jets` utility function and introduces a configurable b-tag threshold for controlling when to use neutrino-regressed jets.

## Key Changes
- **New configuration parameter**: `neutrino_regression_btag_cut` allows flexible control over jet regression strategy:
  - `None`: disabled (uses existing approach logic)
  - `True`: uses loose b-tag working point threshold
  - String (e.g., "M", "T"): uses named working point threshold
  - Float: uses raw b-tag score threshold

- **Refactored jet selection logic**: Replaced inline `ak.where` conditionals with calls to `merge_regressed_jets` utility function for cleaner, more maintainable code

- **Three selection strategies**:
  - `neutrino_regression_btag_cut` enabled: High b-tag jets use +neutrino regression, low b-tag jets use plain regression
  - `approach == "first"`: Uses +neutrino regression where valid, falls back to standard JEC
  - `approach == "second"`: High b-tag jets always use +neutrino regression, low b-tag jets use either +neutrino or standard JEC

- **Added validation**: Checks that required jet collections exist before attempting to merge them, with informative error messages

## Implementation Details
- Imported `merge_regressed_jets` from `pocket_coffea.lib.jets`
- The new parameter integrates with existing b-tagging configuration parameters for working point thresholds
- Maintains backward compatibility: existing `approach` parameter behavior is preserved when `neutrino_regression_btag_cut` is `None`

https://claude.ai/code/session_0194QZWwvPExTQh4PJCe9rTf